### PR TITLE
Report Fisher information matrix in log/output

### DIFF
--- a/main/est_hsq.cpp
+++ b/main/est_hsq.cpp
@@ -886,6 +886,22 @@ void gcta::reml(bool pred_rand_eff, bool est_fix_eff, bool est_fix_eff_var, vect
             o_reml << _hsq_name[j] << "\t" << Hsq[_bivar_pos[0][i]] << "\t" << sqrt(VarHsq[_bivar_pos[0][i]]) << endl;
             o_reml << _hsq_name[j + 1] << "\t" << Hsq[_bivar_pos[1][i]] << "\t" << sqrt(VarHsq[_bivar_pos[1][i]]) << endl;
         }
+        // Print variance-covariance matrix of variance component estimates (Hi)
+        o_reml << "\nVariance-covariance matrix of variance component estimates:" << endl;
+        o_reml << "\t";
+        for (int j = 0; j < _r_indx.size(); j++) {
+            o_reml << _var_name[j];
+            if (j < _r_indx.size() - 1) o_reml << "\t";
+        }
+        o_reml << endl;
+        for (int i = 0; i < _r_indx.size(); i++) {
+            o_reml << _var_name[i] << "\t";
+            for (int j = 0; j < _r_indx.size(); j++) {
+                o_reml << std::setprecision(5) << Hi(i, j);
+                if (j < _r_indx.size() - 1) o_reml << "\t";
+            }
+            o_reml << endl;
+        }
     } else {
         o_reml << "Vp\t" << Vp << "\t" << sqrt(VarVp) << endl;
         for (i = 0; i < Hsq.size(); i++) o_reml << _hsq_name[i] << "\t" << Hsq[i] << "\t" << sqrt(VarHsq[i]) << endl;

--- a/main/est_hsq.cpp
+++ b/main/est_hsq.cpp
@@ -798,6 +798,22 @@ void gcta::reml(bool pred_rand_eff, bool est_fix_eff, bool est_fix_eff_var, vect
             LOGGER << _hsq_name[j] << "\t" << Hsq[_bivar_pos[0][i]] << "\t" << sqrt(VarHsq[_bivar_pos[0][i]]) << endl;
             LOGGER << _hsq_name[j + 1] << "\t" << Hsq[_bivar_pos[1][i]] << "\t" << sqrt(VarHsq[_bivar_pos[1][i]]) << endl;
         }
+        // Print variance-covariance matrix of variance component estimates (Hi)
+        LOGGER << "\nVariance-covariance matrix of variance component estimates:" << endl;
+        LOGGER << "\t";
+        for (int j = 0; j < _r_indx.size(); j++) {
+            LOGGER << _var_name[j];
+            if (j < _r_indx.size() - 1) LOGGER << "\t";
+        }
+        LOGGER << endl;
+        for (int i = 0; i < _r_indx.size(); i++) {
+            LOGGER << _var_name[i] << "\t";
+            for (int j = 0; j < _r_indx.size(); j++) {
+                LOGGER << std::setprecision(5) << Hi(i, j);
+                if (j < _r_indx.size() - 1) LOGGER << "\t";
+            }
+            LOGGER << endl;
+        }
     } else {
         LOGGER << "Vp\t" << Vp << "\t" << sqrt(VarVp) << endl;
         for (i = 0; i < Hsq.size(); i++) LOGGER << _hsq_name[i] << "\t" << Hsq[i] << "\t" << sqrt(VarHsq[i]) << endl;


### PR DESCRIPTION
It would be useful for researchers to have access to the Fisher information matrix of the estimates reported by GREML in order to calculate standard errors of different quantities (e.g. see https://www.biorxiv.org/content/10.1101/2025.11.24.690292v1). 